### PR TITLE
patch: fixed incorrect redirection to /api/auth

### DIFF
--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -4,6 +4,9 @@ import GithubProvider from 'next-auth/providers/github'
 const runtimeConfig = useRuntimeConfig()
 
 export default NuxtAuthHandler({
+  pages: {
+    signIn: '/login',
+  },
   providers: [
     // @ts-expect-error You need to use .default here for it to work during SSR. May be fixed via Vite at some point
     GithubProvider.default({


### PR DESCRIPTION
the auth middleware redirects to /api/auth, when navigating to /dashboard manually, instead of redirecting to /login