### PR TITLE
Fix error handling while sending magic link

### DIFF
--- a/server/utils/magicLink.ts
+++ b/server/utils/magicLink.ts
@@ -241,7 +241,18 @@ export async function sendMagicLinkEmail(
       })
     )
   } catch (error) {
-    console.error('Failed to subscribe email:', error)
+    let errorMessage = ''
+    if (typeof error?.response?.data?.message === 'string') {
+      errorMessage = error.response.data.message
+    } else if (typeof error?.message === 'string') {
+      errorMessage = error.message
+    }
+
+    const isExpectedError = errorMessage?.toLowerCase().includes('conflict')
+
+    if (!isExpectedError) {
+      console.error('Failed to subscribe email:', error)
+    }
   }
 
   try {

--- a/server/utils/magicLink.ts
+++ b/server/utils/magicLink.ts
@@ -218,17 +218,17 @@ export async function sendMagicLinkEmail(
     return
   }
 
+  // Get template ID based on locale
+  const templateId = getTemplateIdByLocale(locale, config.listmonk)
+
+  if (!templateId) {
+    console.warn(
+      `No template ID configured for locale ${locale}, logging magic link instead`
+    )
+    return
+  }
+
   try {
-    // Get template ID based on locale
-    const templateId = getTemplateIdByLocale(locale, config.listmonk)
-
-    if (!templateId) {
-      console.warn(
-        `No template ID configured for locale ${locale}, logging magic link instead`
-      )
-      return
-    }
-
     // subscribe the email to the list first
     await makeListmonkRequest(
       ListmonkEndpoint.SUBSCRIBE_EMAIL,
@@ -240,7 +240,11 @@ export async function sendMagicLinkEmail(
         lists: [config.listId].map(parseInt),
       })
     )
+  } catch (error) {
+    console.error('Failed to subscribe email:', error)
+  }
 
+  try {
     // send the magic link
     await makeListmonkRequest(
       ListmonkEndpoint.SEND_TRANSACTIONAL_EMAIL,


### PR DESCRIPTION
This change handles any error that might occur while subscribing the email and continues to send the magic link.