### PR TITLE
Fix magic link

### DIFF
--- a/server/utils/magicLink.ts
+++ b/server/utils/magicLink.ts
@@ -237,6 +237,7 @@ export async function sendMagicLinkEmail(
         from_email: `${config.listmonk.fromName} <${config.listmonk.fromEmail}>`,
         subscriber_email: email,
         template_id: parseInt(templateId),
+        subscriber_mode: 'external',
         data: {
           link: magicLink,
         },


### PR DESCRIPTION
## Summary

Hotfix for the Listmonk magic link subscriber mode issue. This fix is branched directly from main due to the current state of the development branch.

## What changed

- Added `subscriber_mode: "external"` to the Listmonk `/api/tx` request body to allow magic link emails to be sent to addresses not already in the subscriber list. This unblocks new user onboarding via magic link login.

## Post merge

This fix will also be rebased into the development branch after merging to ensure there is no mismatch between main and development going forward.